### PR TITLE
Add pgadmin service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,18 @@ services:
     networks:
       - ttt_net
 
+  pgadmin:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: root
+    ports:
+      - "5050:80"
+    depends_on:
+      - db
+    networks:
+      - ttt_net
+
   backend:
     build: ./backend
     ports:


### PR DESCRIPTION
Added pgadmin service to docker-compose.yml to facilitate manual database operations.
The service uses dpage/pgadmin4 image and exposes port 5050.

---
*PR created automatically by Jules for task [3260024699014631876](https://jules.google.com/task/3260024699014631876) started by @FelBell*