### PR TITLE
Fix headshot detection in GMod addon

### DIFF
--- a/addon/lua/autorun/server/sv_ttt_stats.lua
+++ b/addon/lua/autorun/server/sv_ttt_stats.lua
@@ -80,7 +80,7 @@ hook.Add("PlayerDeath", "TTTStats_PlayerDeath", function(victim, inflictor, atta
     local kill_info = {
         victim_steamid = victim:SteamID(),
         victim_role = GetRoleName(victim),
-        headshot = (victim.LastHitGroup == HITGROUP_HEAD)
+        headshot = (victim:LastHitGroup() == HITGROUP_HEAD)
     }
 
     if IsValid(attacker) and attacker:IsPlayer() then


### PR DESCRIPTION
Fixed a bug in the Garry's Mod addon where headshots were not being correctly identified. The code was incorrectly accessing `LastHitGroup` as a property instead of calling it as a method. This caused the headshot check to always fail.

Changed:
- `addon/lua/autorun/server/sv_ttt_stats.lua`: Updated `victim.LastHitGroup` to `victim:LastHitGroup()`.

---
*PR created automatically by Jules for task [16285389028237392002](https://jules.google.com/task/16285389028237392002) started by @FelBell*