### PR TITLE
Map Vanilla TTT Item IDs to Names

### DIFF
--- a/addon/lua/autorun/server/sv_ttt_stats.lua
+++ b/addon/lua/autorun/server/sv_ttt_stats.lua
@@ -12,6 +12,29 @@ local cv_api_key = CreateConVar("ttt_stats_api_key", "my_secret_api_key", FCVAR_
 -- Internal State
 local current_round = {}
 
+-- Mapping for vanilla TTT item IDs to names
+local vanilla_item_map = {
+    [1] = "Armor",
+    [2] = "Radar",
+    [3] = "Defuser",
+    [4] = "Flare Gun",
+    [5] = "Health Station",
+    [6] = "Knife",
+    [7] = "C4",
+    [8] = "Disguiser"
+}
+
+-- Helper to get item name
+local function GetItemName(equipment, is_item)
+    if is_item then
+        -- It's a numerical ID for a vanilla item
+        return vanilla_item_map[equipment] or "item_" .. tostring(equipment)
+    else
+        -- It's a weapon class string
+        return tostring(equipment)
+    end
+end
+
 -- Helper to generate UUID v4
 local function GenerateUUID()
     local template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
@@ -122,7 +145,7 @@ hook.Add("TTTOrderedEquipment", "TTTStats_Buy", function(ply, equipment, is_item
     local buy_info = {
         steam_id = ply:SteamID(),
         role = GetRoleName(ply),
-        item = tostring(equipment)
+        item = GetItemName(equipment, is_item)
     }
 
     if not current_round.buys then current_round.buys = {} end


### PR DESCRIPTION
This change updates the Garry's Mod addon to map vanilla TTT item IDs to their human-readable names, ensuring that item purchases are logged with descriptive names instead of numerical IDs. A Lua table has been added to store the item mappings, and the `TTTOrderedEquipment` hook has been updated to use this mapping.

Fixes #9

---
*PR created automatically by Jules for task [12845252243129323646](https://jules.google.com/task/12845252243129323646) started by @FelBell*