### PR TITLE
Add Support for Jackal and Sidekick Roles

### DIFF
--- a/addon/lua/autorun/server/sv_ttt_stats.lua
+++ b/addon/lua/autorun/server/sv_ttt_stats.lua
@@ -54,6 +54,8 @@ local function GetRoleName(ply)
     if role == ROLE_TRAITOR then return "traitor" end
     if role == ROLE_DETECTIVE then return "detective" end
     if role == ROLE_INNOCENT then return "innocent" end
+    if ROLE_JACKAL and role == ROLE_JACKAL then return "jackal" end
+    if ROLE_SIDEKICK and role == ROLE_SIDEKICK then return "sidekick" end
 
     -- Fallback for custom roles or unknown
     return "role_" .. tostring(role)
@@ -167,6 +169,7 @@ hook.Add("TTTEndRound", "TTTStats_EndRound", function(result)
     if (WIN_TRAITOR and result == WIN_TRAITOR) or res_num == 2 then winner = "traitors" end
     if (WIN_INNOCENT and result == WIN_INNOCENT) or res_num == 3 then winner = "innocents" end
     if (WIN_TIMELIMIT and result == WIN_TIMELIMIT) or res_num == 4 then winner = "timelimit" end
+    if WIN_JACKAL and result == WIN_JACKAL then winner = "jackal" end
 
     local end_roles = CollectPlayerRoles()
 


### PR DESCRIPTION
This change adds support for the Jackal and Sidekick roles to the TTT stats collector. The GMod addon is updated to recognize the new roles and win condition, and the backend has been verified to handle the new data without requiring any modifications.

Fixes #10

---
*PR created automatically by Jules for task [17429306864737153878](https://jules.google.com/task/17429306864737153878) started by @FelBell*