### PR TITLE
Add Karma and Points Tracking

### DIFF
--- a/addon/lua/autorun/server/sv_ttt_stats.lua
+++ b/addon/lua/autorun/server/sv_ttt_stats.lua
@@ -62,17 +62,20 @@ local function GetRoleName(ply)
 end
 
 -- Helper to collect all current player roles
-local function CollectPlayerRoles()
-    local roles = {}
+-- Helper to collect all current player info (roles, karma, points)
+local function CollectPlayerInfo()
+    local players = {}
     for _, ply in ipairs(player.GetAll()) do
         if IsValid(ply) then
-            table.insert(roles, {
+            table.insert(players, {
                 player_steamid = ply:SteamID(),
-                role = GetRoleName(ply)
+                role = GetRoleName(ply),
+                karma = ply:GetKarma(),
+                points = ply:GetScore()
             })
         end
     end
-    return roles
+    return players
 end
 
 local function ResetRound()
@@ -82,7 +85,7 @@ local function ResetRound()
         buys = {},
         start_time = os.time(),
         map = game.GetMap(),
-        start_roles = CollectPlayerRoles()
+        start_player_info = CollectPlayerInfo()
     }
     print("[TTT Stats] Round tracking started. ID: " .. current_round.round_id)
 end
@@ -171,15 +174,15 @@ hook.Add("TTTEndRound", "TTTStats_EndRound", function(result)
     if (WIN_TIMELIMIT and result == WIN_TIMELIMIT) or res_num == 4 then winner = "timelimit" end
     if WIN_JACKAL and result == WIN_JACKAL then winner = "jackal" end
 
-    local end_roles = CollectPlayerRoles()
+    local end_player_info = CollectPlayerInfo()
 
     local payload = {
         round_id = current_round.round_id,
         map_name = current_round.map,
         winner = winner,
         duration = duration,
-        start_roles = current_round.start_roles or {},
-        end_roles = end_roles,
+        start_roles = current_round.start_player_info or {},
+        end_roles = end_player_info,
         kills = current_round.kills or {},
         buys = current_round.buys or {}
     }

--- a/backend/app.py
+++ b/backend/app.py
@@ -60,7 +60,12 @@ def collect_stats():
         for p in data.get('start_roles', []):
             sid = p.get('player_steamid')
             if sid:
-                players_dict[sid] = {'steam_id': sid, 'role_start': p.get('role')}
+                players_dict[sid] = {
+                    'steam_id': sid,
+                    'role_start': p.get('role'),
+                    'karma_start': p.get('karma'),
+                    'points_start': p.get('points')
+                }
 
         # End roles
         for p in data.get('end_roles', []):
@@ -69,13 +74,29 @@ def collect_stats():
                 if sid not in players_dict:
                     players_dict[sid] = {'steam_id': sid}
                 players_dict[sid]['role_end'] = p.get('role')
+                players_dict[sid]['karma_end'] = p.get('karma')
+                players_dict[sid]['points_end'] = p.get('points')
 
         for p_data in players_dict.values():
+            karma_start = p_data.get('karma_start')
+            karma_end = p_data.get('karma_end')
+            points_start = p_data.get('points_start')
+            points_end = p_data.get('points_end')
+
+            karma_diff = None
+            if karma_start is not None and karma_end is not None:
+                karma_diff = karma_end - karma_start
+
+            points_diff = None
+            if points_start is not None and points_end is not None:
+                points_diff = points_end - points_start
             new_player = RoundPlayer(
                 round_id=new_round.id,
                 steam_id=p_data['steam_id'],
                 role_start=p_data.get('role_start'),
-                role_end=p_data.get('role_end')
+                role_end=p_data.get('role_end'),
+                karma_diff=karma_diff,
+                points_diff=points_diff
             )
             db.session.add(new_player)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -83,13 +83,17 @@ class RoundPlayer(db.Model):
     steam_id = db.Column(db.String(64), nullable=False)
     role_start = db.Column(db.String(32))
     role_end = db.Column(db.String(32))
+    karma_diff = db.Column(db.Integer)
+    points_diff = db.Column(db.Integer)
 
     def to_dict(self):
         """Returns a dictionary representation of the RoundPlayer."""
         return {
             'steam_id': self.steam_id,
             'role_start': self.role_start,
-            'role_end': self.role_end
+            'role_end': self.role_end,
+            'karma_diff': self.karma_diff,
+            'points_diff': self.points_diff
         }
 
 class Kill(db.Model):


### PR DESCRIPTION
This change adds support for tracking karma and points changes per player, per round. It updates the backend to calculate and store the differences, and modifies the GMod addon to collect the necessary data.

Fixes #14

---
*PR created automatically by Jules for task [18136220179741125846](https://jules.google.com/task/18136220179741125846) started by @FelBell*