### PR TITLE
Fix Lua error for GetKarma

### DIFF
--- a/addon/lua/autorun/server/sv_ttt_stats.lua
+++ b/addon/lua/autorun/server/sv_ttt_stats.lua
@@ -70,7 +70,7 @@ local function CollectPlayerInfo()
             table.insert(players, {
                 player_steamid = ply:SteamID(),
                 role = GetRoleName(ply),
-                karma = ply:GetKarma(),
+                karma = ply:Karma(),
                 points = ply:GetScore()
             })
         end


### PR DESCRIPTION
Fixed a Lua error in the Garry's Mod addon. The error `attempt to call method 'GetKarma' (a nil value)` was caused by an incorrect function call. Replaced `ply:GetKarma()` with the correct TTT2 function `ply:Karma()`.

Fixes #16

---
*PR created automatically by Jules for task [8597039930063140484](https://jules.google.com/task/8597039930063140484) started by @FelBell*