### PR TITLE
Track Unique Players

### DIFF
--- a/addon/lua/autorun/server/sv_ttt_stats.lua
+++ b/addon/lua/autorun/server/sv_ttt_stats.lua
@@ -212,4 +212,38 @@ hook.Add("TTTEndRound", "TTTStats_EndRound", function(result)
     current_round = {}
 end)
 
+hook.Add("PlayerInitialSpawn", "TTTStats_PlayerInitialSpawn", function(ply)
+    if not IsValid(ply) or not ply:IsPlayer() then return end
+
+    local payload = {
+        steam_id = ply:SteamID(),
+        display_name = ply:Nick()
+    }
+
+    local json_body = util.TableToJSON(payload)
+    -- Construct the player update URL from the base API URL
+    local base_api_url = cv_api_url:GetString()
+    -- Ensure the base URL doesn't have a trailing slash, then append the new path
+    local player_api_url = base_api_url:gsub("/$", "") .. "/player/update"
+
+
+    print("[TTT Stats] Sending player data to " .. player_api_url)
+
+    HTTP({
+        failed = function(reason)
+            print("[TTT Stats] Player update HTTP Request Failed: " .. reason)
+        end,
+        success = function(code, body, headers)
+            print("[TTT Stats] Player update HTTP Request Success: " .. code)
+        end,
+        method = "POST",
+        url = player_api_url,
+        body = json_body,
+        headers = {
+            ["Content-Type"] = "application/json",
+            ["X-Api-Key"] = cv_api_key:GetString()
+        }
+    })
+end)
+
 print("[TTT Stats] Addon Loaded.")

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,7 +48,29 @@ Records equipment purchases during a round.
 - `role` (String(32)): Role of the player at the time of purchase.
 - `item` (String(64)): Item identifier or weapon class.
 
+### `players`
+Stores unique player information.
+- `steam_id` (String(64), PK): The player's unique SteamID.
+- `display_name` (String(128)): The player's last known display name.
+
 ## Endpoints
+
+### POST `/api/player/update`
+
+Creates or updates a player's display name. This is intended to be called when a player joins the server to keep their name up-to-date.
+
+**Headers:**
+- `Content-Type: application/json`
+- `X-Api-Key: <YOUR_API_KEY>`
+
+**Payload:**
+
+```json
+{
+  "steam_id": "STEAM_0:1:12345",
+  "display_name": "PlayerName"
+}
+```
 
 ### POST `/api/collect`
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -131,3 +131,20 @@ class Kill(db.Model):
             'weapon': self.weapon,
             'headshot': self.headshot
         }
+
+class Player(db.Model):
+    """
+    Represents a unique player.
+    Attributes:
+        steam_id (str): The player's SteamID, serving as the primary key.
+        display_name (str): The player's last known display name.
+    """
+    __tablename__ = 'players'
+    steam_id = db.Column(db.String(64), primary_key=True)
+    display_name = db.Column(db.String(128), nullable=False)
+    def to_dict(self):
+        """Returns a dictionary representation of the Player."""
+        return {
+            'steam_id': self.steam_id,
+            'display_name': self.display_name
+        }

--- a/backend/reset_db.py
+++ b/backend/reset_db.py
@@ -1,4 +1,6 @@
 from app import app, db
+# Import all models to ensure they are registered with SQLAlchemy before create_all() is called
+from models import Player, Round, RoundBuy, RoundPlayer, Kill
 
 if __name__ == "__main__":
     with app.app_context():


### PR DESCRIPTION
This feature introduces a new system for tracking unique players. A `Player` table has been added to the database to store player information, and a new API endpoint, `/api/player/update`, is now available to create or update player records. The GMod addon has been updated to send player data to this endpoint whenever a player joins the server. Additionally, the backend documentation has been updated to reflect these changes.

Fixes #20

---
*PR created automatically by Jules for task [2746798894604065945](https://jules.google.com/task/2746798894604065945) started by @FelBell*