### PR TITLE
Remove item_ prefix from item names

### DIFF
--- a/addon/lua/autorun/server/sv_ttt_stats.lua
+++ b/addon/lua/autorun/server/sv_ttt_stats.lua
@@ -26,15 +26,13 @@ local vanilla_item_map = {
 
 -- Helper to get item name
 local function GetItemName(equipment, is_item)
-    local name
     if is_item then
         -- It's a numerical ID for a vanilla item
-        name = vanilla_item_map[equipment] or "item_" .. tostring(equipment)
+        return vanilla_item_map[equipment] or tostring(equipment)
     else
         -- It's a weapon class string
-        name = tostring(equipment)
+        return tostring(equipment)
     end
-    return name:gsub("^item_", "")
 end
 
 -- Helper to generate UUID v4


### PR DESCRIPTION
This change modifies the `GetItemName` function in `addon/lua/autorun/server/sv_ttt_stats.lua` to remove the `item_` prefix from the names of bought items. This is done to prevent duplication in the display of item names.

Fixes #21

---
*PR created automatically by Jules for task [16255553459449068876](https://jules.google.com/task/16255553459449068876) started by @FelBell*