### PR TITLE
Fix Round Winner Mapping

### DIFF
--- a/addon/lua/autorun/server/sv_ttt_stats.lua
+++ b/addon/lua/autorun/server/sv_ttt_stats.lua
@@ -167,16 +167,8 @@ hook.Add("TTTEndRound", "TTTStats_EndRound", function(result)
 
     local duration = os.time() - current_round.start_time
 
-    -- Map result enum to string
-    local winner = "unknown"
-    print("[TTT Stats] Round ended with result: " .. tostring(result))
-
-    local res_num = tonumber(result)
-
-    if (WIN_TRAITOR and result == WIN_TRAITOR) or res_num == 2 then winner = "traitors" end
-    if (WIN_INNOCENT and result == WIN_INNOCENT) or res_num == 3 then winner = "innocents" end
-    if (WIN_TIMELIMIT and result == WIN_TIMELIMIT) or res_num == 4 then winner = "timelimit" end
-    if WIN_JACKAL and result == WIN_JACKAL then winner = "jackal" end
+    local winner = tostring(result)
+    print("[TTT Stats] Round ended with result: " .. winner)
 
     local end_player_info = CollectPlayerInfo()
 


### PR DESCRIPTION
This change addresses the issue where the round winner is not correctly mapped by passing the raw `result` from the `TTTEndRound` hook as a string.

Fixes #12

---
*PR created automatically by Jules for task [7106327715610633733](https://jules.google.com/task/7106327715610633733) started by @FelBell*