### PR TITLE
Send player nicknames instead of Steam IDs in API

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -144,7 +144,12 @@ def get_stats():
     offset = request.args.get('offset', 0, type=int)
 
     rounds = Round.query.order_by(Round.timestamp.desc()).offset(offset).limit(limit).all()
-    return jsonify([r.to_dict() for r in rounds])
+
+    # Fetch all players to create a mapping for nicknames
+    players = Player.query.all()
+    player_map = {p.steam_id: p.display_name for p in players}
+
+    return jsonify([r.to_dict(player_map) for r in rounds])
 
 @app.route('/api/player/update', methods=['POST'])
 @require_api_key

--- a/backend/models.py
+++ b/backend/models.py
@@ -27,7 +27,7 @@ class Round(db.Model):
     players = db.relationship('RoundPlayer', backref='round', lazy=True)
     buys = db.relationship('RoundBuy', backref='round', lazy=True)
 
-    def to_dict(self):
+    def to_dict(self, player_map=None):
         """Returns a dictionary representation of the Round."""
         return {
             'id': self.id,
@@ -35,9 +35,9 @@ class Round(db.Model):
             'winner': self.winner,
             'duration': self.duration,
             'timestamp': self.timestamp.isoformat() if self.timestamp else None,
-            'kills': [k.to_dict() for k in self.kills],
-            'players': [p.to_dict() for p in self.players],
-            'buys': [b.to_dict() for b in self.buys]
+            'kills': [k.to_dict(player_map) for k in self.kills],
+            'players': [p.to_dict(player_map) for p in self.players],
+            'buys': [b.to_dict(player_map) for b in self.buys]
         }
 
 class RoundBuy(db.Model):
@@ -58,10 +58,14 @@ class RoundBuy(db.Model):
     role = db.Column(db.String(32))
     item = db.Column(db.String(64))
 
-    def to_dict(self):
+    def to_dict(self, player_map=None):
         """Returns a dictionary representation of the RoundBuy."""
+        steam_id = self.steam_id
+        if player_map and steam_id in player_map:
+            steam_id = player_map[steam_id]
+
         return {
-            'steam_id': self.steam_id,
+            'steam_id': steam_id,
             'role': self.role,
             'item': self.item
         }
@@ -86,10 +90,14 @@ class RoundPlayer(db.Model):
     karma_diff = db.Column(db.Integer)
     points_diff = db.Column(db.Integer)
 
-    def to_dict(self):
+    def to_dict(self, player_map=None):
         """Returns a dictionary representation of the RoundPlayer."""
+        steam_id = self.steam_id
+        if player_map and steam_id in player_map:
+            steam_id = player_map[steam_id]
+
         return {
-            'steam_id': self.steam_id,
+            'steam_id': steam_id,
             'role_start': self.role_start,
             'role_end': self.role_end,
             'karma_diff': self.karma_diff,
@@ -121,12 +129,20 @@ class Kill(db.Model):
     weapon = db.Column(db.String(64))
     headshot = db.Column(db.Boolean, default=False)
 
-    def to_dict(self):
+    def to_dict(self, player_map=None):
         """Returns a dictionary representation of the Kill."""
+        attacker_steamid = self.attacker_steamid
+        if player_map and attacker_steamid in player_map:
+            attacker_steamid = player_map[attacker_steamid]
+
+        victim_steamid = self.victim_steamid
+        if player_map and victim_steamid in player_map:
+            victim_steamid = player_map[victim_steamid]
+
         return {
-            'attacker_steamid': self.attacker_steamid,
+            'attacker_steamid': attacker_steamid,
             'attacker_role': self.attacker_role,
-            'victim_steamid': self.victim_steamid,
+            'victim_steamid': victim_steamid,
             'victim_role': self.victim_role,
             'weapon': self.weapon,
             'headshot': self.headshot

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -15,23 +15,6 @@ import { environment } from '../../../environments/environment';
 export class DashboardComponent {
   private readonly apiUrl = environment.apiUrl;
 
-  // Hardcoded Steam ID to Display Name mapping
-  private readonly steamIdDisplayNames: Record<string, string> = {
-    'STEAM_0:0:130645458': 'Señor del Mapa',
-    'STEAM_0:1:619571923': 'cHoli',
-    'STEAM_0:0:504917834': 'gebrochen',
-    'STEAM_0:1:171849502': 'matze161',
-    'STEAM_0:1:949098480': 'Der Papa',
-    'STEAM_0:1:512869438': 'Toodels',
-    'STEAM_0:1:39907607': 'Lumien',
-    'STEAM_0:0:158949535': 'Sauron',
-    'STEAM_0:1:87186570': 'sim.lie',
-    'STEAM_0:0:140709318': '☭☭☭ Uppercut Ursula',
-    'STEAM_0:1:94263852': 'ben.liedel',
-    'STEAM_0:0:624153889': 'Mink',
-    'STEAM_0:0:638665069': 'soeren.hem',
-  };
-
   // Pagination signals
   currentPage = signal(0);
   pageSize = 20;
@@ -199,17 +182,12 @@ export class DashboardComponent {
 
   formatSteamId(steamId: string | null): string {
     if (!steamId) return 'Welt';
-    // Check if we have a display name for this Steam ID
-    if (this.steamIdDisplayNames[steamId]) {
-      return this.steamIdDisplayNames[steamId];
-    }
-    // Shorten for display
-    return steamId.replace('STEAM_', 'S:');
+    return steamId;
   }
 
   getDisplayName(steamId: string | null): string {
     if (!steamId) return 'Welt';
-    return this.steamIdDisplayNames[steamId] ?? steamId.replace('STEAM_', 'S:');
+    return steamId;
   }
 
   trackByRoundId(index: number, round: Round): string {

--- a/frontend/src/app/components/statistics/statistics.component.ts
+++ b/frontend/src/app/components/statistics/statistics.component.ts
@@ -95,23 +95,6 @@ export class StatisticsComponent {
   private readonly apiUrl = environment.apiUrl;
   private readonly injector = inject(Injector);
 
-  // Hardcoded Steam ID to Display Name mapping
-  private readonly steamIdDisplayNames: Record<string, string> = {
-    'STEAM_0:0:130645458': 'Señor del Mapa',
-    'STEAM_0:1:619571923': 'cHoli',
-    'STEAM_0:0:504917834': 'gebrochen',
-    'STEAM_0:1:171849502': 'matze161',
-    'STEAM_0:1:949098480': 'Der Papa',
-    'STEAM_0:1:512869438': 'Toodels',
-    'STEAM_0:1:39907607': 'Lumien',
-    'STEAM_0:0:158949535': 'Sauron',
-    'STEAM_0:1:87186570': 'sim.lie',
-    'STEAM_0:0:140709318': '☭☭☭ Uppercut Ursula',
-    'STEAM_0:1:94263852': 'ben.liedel',
-    'STEAM_0:0:624153889': 'Mink',
-    'STEAM_0:0:638665069': 'soeren.hem',
-  };
-
   // Chart refs
   winRateChartCanvas = viewChild<ElementRef<HTMLCanvasElement>>('winRateChart');
   killsChartCanvas = viewChild<ElementRef<HTMLCanvasElement>>('killsChart');
@@ -966,7 +949,7 @@ export class StatisticsComponent {
 
   getDisplayName(steamId: string | null): string {
     if (!steamId) return 'Welt';
-    return this.steamIdDisplayNames[steamId] ?? steamId.replace('STEAM_', 'S:');
+    return steamId;
   }
 
   formatDuration(seconds: number): string {


### PR DESCRIPTION
The backend now returns player nicknames instead of Steam IDs in the round statistics API. This is achieved by looking up the nicknames in the existing `Player` table. The frontend has been updated to remove its hardcoded mappings and directly display the names provided by the backend. Fallback logic ensures that if a nickname is not found, the original Steam ID is still shown.

Fixes #39

---
*PR created automatically by Jules for task [1251445935964450910](https://jules.google.com/task/1251445935964450910) started by @FelBell*